### PR TITLE
Enable compilation of YARP devices by backporting PR 576

### DIFF
--- a/recipe/576.patch
+++ b/recipe/576.patch
@@ -1,0 +1,25 @@
+From 53635d552ea250d22dc71a18fb776ee977153fe7 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio.traversaro@iit.it>
+Date: Thu, 24 Nov 2022 13:06:03 +0100
+Subject: [PATCH] AddBipedalLocomotionYARPDevice: Enable YARP devices by
+ deafult
+
+---
+ cmake/AddBipedalLocomotionYARPDevice.cmake | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/cmake/AddBipedalLocomotionYARPDevice.cmake b/cmake/AddBipedalLocomotionYARPDevice.cmake
+index c88b7a80a..3d2068af6 100644
+--- a/cmake/AddBipedalLocomotionYARPDevice.cmake
++++ b/cmake/AddBipedalLocomotionYARPDevice.cmake
+@@ -41,7 +41,9 @@ function(add_bipedal_yarp_device)
+ 
+   yarp_prepare_plugin(${name} CATEGORY device
+                               TYPE ${type}
+-                              INCLUDE ${public_headers})
++                              INCLUDE ${public_headers}
++                              OPTION ENABLE_${name}
++                              DEFAULT ON)
+ 
+   if(NOT SKIP_${name})
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
   sha256: 28287535172fd25289df80a2f806fbfd92c021dec2750d7613e3343481a7c21c
   patches:
     - 564.patch
+    - 576.patch
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: {{ namecxx }}


### PR DESCRIPTION
Fix https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/issues/5 .
Backport of https://github.com/ami-iit/bipedal-locomotion-framework/pull/576 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
