### PR TITLE
Do not use jinja variable in output names as it is not supported by migrators

### DIFF
--- a/.ci_support/migrations/idyntree12.yaml
+++ b/.ci_support/migrations/idyntree12.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for idyntree 12
-  kind: version
-  migration_number: 1
-idyntree:
-- '12'
-migrator_ts: 1711391201.1544764

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About bipedal-locomotion-framework-feedstock
-============================================
+About bipedal-locomotion-framework-split-feedstock
+==================================================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/blob/main/LICENSE.txt)
 
@@ -78,10 +78,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-bipedal--locomotion--framework--python-green.svg)](https://anaconda.org/conda-forge/bipedal-locomotion-framework-python) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/bipedal-locomotion-framework-python.svg)](https://anaconda.org/conda-forge/bipedal-locomotion-framework-python) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/bipedal-locomotion-framework-python.svg)](https://anaconda.org/conda-forge/bipedal-locomotion-framework-python) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/bipedal-locomotion-framework-python.svg)](https://anaconda.org/conda-forge/bipedal-locomotion-framework-python) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libbipedal--locomotion--framework-green.svg)](https://anaconda.org/conda-forge/libbipedal-locomotion-framework) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libbipedal-locomotion-framework.svg)](https://anaconda.org/conda-forge/libbipedal-locomotion-framework) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libbipedal-locomotion-framework.svg)](https://anaconda.org/conda-forge/libbipedal-locomotion-framework) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libbipedal-locomotion-framework.svg)](https://anaconda.org/conda-forge/libbipedal-locomotion-framework) |
 
-Installing bipedal-locomotion-framework
-=======================================
+Installing bipedal-locomotion-framework-split
+=============================================
 
-Installing `bipedal-locomotion-framework` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `bipedal-locomotion-framework-split` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -167,17 +167,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating bipedal-locomotion-framework-feedstock
-===============================================
+Updating bipedal-locomotion-framework-split-feedstock
+=====================================================
 
-If you would like to improve the bipedal-locomotion-framework recipe or build a new
+If you would like to improve the bipedal-locomotion-framework-split recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/bipedal-locomotion-framework-feedstock are
+Note that all branches in the conda-forge/bipedal-locomotion-framework-split-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,12 @@
+# Note: we use this variable everywhere except in outputs names as jinja variables in output names are not supported
+# by migrators, see https://github.com/conda-forge/librobometry-feedstock/pull/20#issuecomment-2041618340
 {% set name = "bipedal-locomotion-framework" %}
 {% set namecxx = "libbipedal-locomotion-framework" %}
 {% set namepython = "bipedal-locomotion-framework-python" %}
 {% set version = "0.18.0" %}
 
 package:
-  name: {{ name }}
+  name: {{ name }}-split
   version: {{ version }}
 
 source:
@@ -13,10 +15,11 @@ source:
   patches:
 
 build:
-  number: 5
+  number: 6
 
 outputs:
-  - name: {{ namecxx }}
+  # {{ namecxx }}
+  - name: "libbipedal-locomotion-framework"
     script: build_cxx.sh  # [unix]
     script: bld_cxx.bat  # [win]
     build:
@@ -83,7 +86,8 @@ outputs:
         - if not exist %PREFIX%\\Library\\bin\\BipedalLocomotionFrameworkSystem.dll exit 1  # [win]
         - if not exist %PREFIX%\\Library\\CMake\\BipedalLocomotionFrameworkConfig.cmake exit 1  # [win]
 
-  - name: {{ namepython }}
+  # {{ namepython }}
+  - name: "bipedal-locomotion-framework-python"
     script: build_py.sh  # [unix]
     script: bld_py.bat  # [win]
     build:
@@ -149,7 +153,8 @@ outputs:
       imports:
         - bipedal_locomotion_framework
 
-  - name: {{ name }}
+  # {{ name }}
+  - name: "bipedal-locomotion-framework"
     build:
       run_exports:
         - {{ pin_subpackage(namecxx, max_pin='x.x.x') }}


### PR DESCRIPTION
See discussion in https://github.com/conda-forge/librobometry-feedstock/pull/20#issuecomment-2041618340 . Not doing this, the `boost` migrators if failing with error (see https://github.com/regro/cf-scripts/actions/runs/8595058000):

~~~
bot error (
[bot CI job](https://github.com/regro/cf-scripts/actions/runs/8595058000)
): main: Traceback (most recent call last):
  File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/auto_tick.py", line 1272, in _run_migrator
    migrator_uid, pr_json = run(
                            ^^^^
  File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/auto_tick.py", line 243, in run
    migrator.run_pre_piggyback_migrations(recipe_dir, feedstock_ctx.attrs, **kwargs)
  File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/migrators/core.py", line 262, in run_pre_piggyback_migrations
    mini_migrator.migrate(recipe_dir, attrs, **kwargs)
  File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/migrators/cstdlib.py", line 207, in migrate
    sections = _slice_into_output_sections(lines, attrs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/migrators/libboost.py", line 48, in _slice_into_output_sections
    raise RuntimeError("Could not find all output sections in meta.yaml!")
RuntimeError: Could not find all output sections in meta.yaml!
~~~

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
