### PR TITLE
Pin CMake to 3.29.0 and re-render to avoid CMake 3.29.1 and vs2022 regressions

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - vs2019
 c_stdlib:
 - vs
+c_stdlib_version:
+- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   patches:
 
 build:
-  number: 7
+  number: 8
 
 outputs:
   # {{ namecxx }}
@@ -30,7 +30,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ stdlib("c") }}
         - {{ compiler('cxx') }}
-        - cmake
+        - cmake==3.29.0
         - pkg-config
         - ninja
         - {{ cdt('mesa-libgl-devel') }}  # [linux]
@@ -103,7 +103,7 @@ outputs:
         - pybind11
         - pybind11-abi
         - ninja
-        - cmake
+        - cmake==3.29.0
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - pybind11                               # [build_platform != target_platform]


### PR DESCRIPTION
Workarounds for:
* https://github.com/ami-iit/bipedal-locomotion-framework/pull/835
* https://github.com/conda-forge/conda-forge.github.io/issues/2102#issuecomment-2043560833

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
