### PR TITLE
Remove conda_build_config.yaml with vkt==9.3.0 pin and re-enable Python  bindings on aarch64

### DIFF
--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -26,6 +26,8 @@ fmt:
 - '11'
 idyntree:
 - '13'
+libboost_devel:
+- '1.86'
 libmatio_cpp:
 - 0.2.5
 libopencv:
@@ -34,8 +36,26 @@ libosqp:
 - 0.6.3
 libyarp:
 - 3.9.0
+numpy:
+- '1.22'
+- '1.23'
+- '1.26'
+- '1.22'
 pcl:
 - 1.14.1
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pugixml:
+- '1.14'
+pybind11_abi:
+- '4'
+python:
+- 3.10.* *_cpython
+- 3.11.* *_cpython
+- 3.12.* *_cpython
+- 3.9.* *_cpython
 qhull:
 - '2020.2'
 spdlog:
@@ -49,3 +69,5 @@ zip_keys:
   - cxx_compiler_version
 - - c_stdlib_version
   - cdt_name
+- - python
+  - numpy

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-# Workaround for https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/6306
-# Remove once vtk-base is pinned
-vtk_base:
-  - "9.3.0"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,7 @@ outputs:
         - librealsense  # [not win]
         - xorg-libxfixes  # [linux]
         # Workaround for https://github.com/conda-forge/pcl-feedstock/pull/68
-        - vtk-base * qt*_207  # [not win]
+        - vtk-base * qt*  # [not win]
       run:
         # manif and eigen are mentioned in the headers so needed when building
         # against libbipedal-locomotion-framework

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,8 +73,7 @@ outputs:
         - librealsense  # [not win]
         - xorg-libxfixes  # [linux]
         # Workaround for https://github.com/conda-forge/pcl-feedstock/pull/68
-        - vtk-base * qt*  # [not win]
-        - vtk-base 9.3.1 *204*
+        - vtk-base * qt*_204  # [not win]
       run:
         # manif and eigen are mentioned in the headers so needed when building
         # against libbipedal-locomotion-framework

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,7 @@ outputs:
         - librealsense  # [not win]
         - xorg-libxfixes  # [linux]
         # Workaround for https://github.com/conda-forge/pcl-feedstock/pull/68
-        - vtk-base * qt*  # [not win]
+        - vtk-base * qt*_207  # [not win]
       run:
         # manif and eigen are mentioned in the headers so needed when building
         # against libbipedal-locomotion-framework

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,6 +74,7 @@ outputs:
         - xorg-libxfixes  # [linux]
         # Workaround for https://github.com/conda-forge/pcl-feedstock/pull/68
         - vtk-base * qt*  # [not win]
+        - vtk-base 9.3.1 *204*
       run:
         # manif and eigen are mentioned in the headers so needed when building
         # against libbipedal-locomotion-framework
@@ -83,7 +84,6 @@ outputs:
         - tomlplusplus
         # Workaround for https://github.com/conda-forge/pcl-feedstock/pull/68
         - vtk-base * qt*  # [not win]
-        - "vtk-base >=9.3.1[build_number=204]"
     test:
       commands:
         - test -f ${PREFIX}/include/BipedalLocomotion/System/Advanceable.h  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ stdlib("c") }}
         - {{ compiler('cxx') }}
-        - cmake==3.29.0
+        - cmake
         - pkg-config
         - ninja
         # YARP idl tools are used in this recipe
@@ -110,7 +110,7 @@ outputs:
         - pybind11
         - pybind11-abi
         - ninja
-        - cmake==3.29.0
+        - cmake
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - pybind11                               # [build_platform != target_platform]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,7 @@ outputs:
         - tomlplusplus
         # Workaround for https://github.com/conda-forge/pcl-feedstock/pull/68
         - vtk-base * qt*  # [not win]
-
+        - "vtk-base >=9.3.1[build_number=204]"
     test:
       commands:
         - test -f ${PREFIX}/include/BipedalLocomotion/System/Advanceable.h  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - 891.patch
 
 build:
-  number: 3
+  number: 4
 
 outputs:
   # {{ namecxx }}
@@ -102,8 +102,6 @@ outputs:
       # icub-models is used just for tests, we do not actually link the C++ library
       ignore_run_exports:
         - icub-models
-      # Workaround for https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/pull/85#issuecomment-2364616366
-      skip: True              # [aarch64]
     requirements:
       build:
         - {{ compiler('c') }}
@@ -165,12 +163,9 @@ outputs:
     build:
       run_exports:
         - {{ pin_subpackage(namecxx, max_pin='x.x.x') }}
-      # Workaround for https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/pull/85#issuecomment-2364616366
-      skip: True              # [aarch64]
     requirements:
       run:
         - {{ pin_subpackage(namecxx, exact=True) }}
-        # Workaround for       # Workaround for https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/pull/85#issuecomment-2364616366
         - {{ pin_subpackage(namepython, max_pin='x.x.x') }}
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,7 @@ outputs:
         - librealsense  # [not win]
         - xorg-libxfixes  # [linux]
         # Workaround for https://github.com/conda-forge/pcl-feedstock/pull/68
-        - vtk-base * qt*_204  # [not win]
+        - vtk-base * qt*  # [not win]
       run:
         # manif and eigen are mentioned in the headers so needed when building
         # against libbipedal-locomotion-framework


### PR DESCRIPTION
Fix https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/issues/89 .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
