### PR TITLE
Add pybind11_abi11 migration manually

### DIFF
--- a/.ci_support/migrations/pybind11_abi11.yaml
+++ b/.ci_support/migrations/pybind11_abi11.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for pybind11 3 and pybind11_abi 11
+  kind: version
+  migration_number: 1
+migrator_ts: 1752454025.946169
+pybind11_abi:
+- '11'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: 80644dae4a4652f7077efade7c675882b8440f665476555338a793b86ccd107f
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   # {{ namecxx }}
@@ -113,8 +113,7 @@ outputs:
       host:
         - {{ pin_subpackage(namecxx, exact=True) }}
         - python
-        # Workaround for https://github.com/conda-forge/pybind11-feedstock/pull/94#issuecomment-2033804227
-        - pybind11 <2.12.0
+        - pybind11
         - pybind11-abi
         - liblie-group-controllers
         - libyarp


### PR DESCRIPTION
The existing pin/constraints of pybind11 were preventing the migrator from actually opening the migration PR.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
